### PR TITLE
feat(connection): add auth headers

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -1,14 +1,15 @@
 export default class Connection {
-  constructor(url) {
-    if (typeof url !== 'string') {
-      throw new Error('url parameter of type "string" is required');
-    }
-    this.url = url;
+  constructor(options) {
+    this.url = options.API_URL;
+    this.apiKey = options.API_KEY;
   }
 
   get(endpoint) {
+    const headers = new Headers();
+    headers.append('Authorization', this.apiKey);
     const options = {
-      method: 'GET'
+      method: 'GET',
+      headers
     };
 
     return fetch(this.url + endpoint, options)
@@ -16,9 +17,12 @@ export default class Connection {
   }
 
   post(data, endpoint) {
+    const headers = new Headers();
+    headers.append('Authorization', this.apiKey);
     const options = {
       method: 'POST',
-      body: data
+      body: data,
+      headers
     };
 
     return fetch(this.url + endpoint, options)

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -1,16 +1,11 @@
 import Connection from '../src/connection/connection';
 
 describe('Connection', () => {
-  it('should not construct with invalid values', () => {
-    [0, {}, [], true, false, null, undefined].map(v => {
-      expect(() => {
-        new Connection(v);
-      }).toThrowError('url parameter of type "string" is required');
-    });
-  });
-
   it('should construct with a valid value', () => {
-    const conn = new Connection('url');
+    const options = {
+      API_URL: 'url'
+    };
+    const conn = new Connection(options);
     expect(conn.url).toBe('url');
   });
 
@@ -26,8 +21,11 @@ describe('Connection', () => {
     });
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
     const url = '127.0.0.1';
+    const options = {
+      API_URL: url
+    };
     const endpoint = '/containers';
-    const conn = new Connection(url);
+    const conn = new Connection(options);
     conn.get(endpoint)
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;
@@ -54,8 +52,11 @@ describe('Connection', () => {
     };
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
     const url = '127.0.0.1';
+    const options = {
+      API_URL: url
+    };
     const endpoint = '/containers';
-    const conn = new Connection(url);
+    const conn = new Connection(options);
     conn.post(postData, endpoint)
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;


### PR DESCRIPTION
Api keys can now be given in the connection constructor.